### PR TITLE
adding getZoneDayReport to fetch historic zone readings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ trigger the API. If the message on the input contains any of the following field
 * zoneId
 * deviceId
 * power
+* reportDate 
 * temperature
 * terminationType
 * terminationTimeout

--- a/locales/en-US/tado.json
+++ b/locales/en-US/tado.json
@@ -9,7 +9,8 @@
             "power": "Heating On/Off",
             "temperature": "Temperature (C)",
             "termination-type": "Type of Termination",
-            "termination-timeout": "Termination Timeout (secs)"
+            "termination-timeout": "Termination Timeout (secs)",
+            "reportDate": "Report Date"
         },
         "option": {
             "get-me": "Get the current user",
@@ -32,7 +33,8 @@
             "auto": "Tado schedule termination",
             "timer": "Timer based termination",
             "on": "Heating On",
-            "off": "Heating Off"
+            "off": "Heating Off",
+	    "get-zone-day-report": "Get a zone's day report."
         }
     }
 }

--- a/locales/en-US/tado.json
+++ b/locales/en-US/tado.json
@@ -10,7 +10,7 @@
             "temperature": "Temperature (C)",
             "termination-type": "Type of Termination",
             "termination-timeout": "Termination Timeout (secs)",
-            "reportDate": "Report Date"
+            "reportDate": "Report Date (yyyy-mm-dd)"
         },
         "option": {
             "get-me": "Get the current user",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.6",
   "description": "Tado web API client node for Node Red",
   "dependencies": {
-    "node-tado-client": "^0.1.1"
+    "node-tado-client": "^0.2.0"
   },
   "devDependencies": {},
   "scripts": {},

--- a/tado.html
+++ b/tado.html
@@ -126,6 +126,9 @@
         <dt class="optional">power <span class="property-type">string</span></dt>
         <dd> turn the heating system on or off</dd>
 
+        <dt class="optional">reportDate <span class="property-type">string</span></dt>
+        <dd> the date in <code>yyyy-mm-dd</code> notation to fetch the report data from</dd>
+
         <dt class="optional">temperature <span class="property-type">string</span></dt>
         <dd> the target temperature</dd>
 

--- a/tado.html
+++ b/tado.html
@@ -54,6 +54,7 @@
             <option value="clearZoneOverlay" data-i18n="tado.option.clear-zone-overlay"></option>
             <option value="setZoneOverlay" data-i18n="tado.option.set-zone-overlay"></option>
             <option value="identifyDevice" data-i18n="tado.option.identify-device"></option>
+            <option value="getZoneDayReport" data-i18n="tado.option.get-zone-day-report"></option>
         </select>
     </div>
     <div class="form-row" id="tadoHomeId">
@@ -67,6 +68,10 @@
     <div class="form-row" id="tadoZoneId">
         <label for="node-input-zoneId"><i class="fa fa-th"></i> <span data-i18n="tado.label.zone-id"></span></label>
         <input type="text" id="node-input-zoneId" data-i18n="[placeholder]tado.label.zone-id">
+    </div>
+    <div class="form-row" id="tadoReportDate">
+        <label for="node-input-tadoReportDate"><i class="fa fa-th"></i> <span data-i18n="tado.label.reportDate"></span></label>
+        <input type="text" id="node-input-tadoReportDate" data-i18n="[placeholder]tado.label.reportDate">
     </div>
     <div id="tadoOverlayForm">
         <div class="form-row" id="tadoPower">
@@ -164,7 +169,8 @@
             temperature: {value: "18"},
             terminationType: {value: "manual"},
             terminationTimeout: {value: 900, validate: RED.validators.number()},
-            name: {value: ""}
+            name: {value: ""},
+            reportDate: {value: ""}
         },
         inputs: 1,
         outputs: 1,
@@ -184,6 +190,7 @@
                         $('#tadoZoneId').hide();
                         $('#tadoDeviceId').hide();
                         $('#tadoOverlayForm').hide();
+                        $('#tadoReportDate').hide();
                         break;
                     case "getHome":
                     case "getWeather":
@@ -196,6 +203,7 @@
                         $('#tadoZoneId').hide();
                         $('#tadoDeviceId').hide();
                         $('#tadoOverlayForm').hide();
+                        $('#tadoReportDate').hide();
                         break;
                     case "getMobileDevice":
                     case "getMobileDeviceSettings":
@@ -203,6 +211,7 @@
                         $('#tadoZoneId').hide();
                         $('#tadoDeviceId').show();
                         $('#tadoOverlayForm').hide();
+                        $('#tadoReportDate').hide();
                         break;
                     case "getZoneState":
                     case "getZoneCapabilities":
@@ -212,18 +221,28 @@
                         $('#tadoZoneId').show();
                         $('#tadoDeviceId').hide();
                         $('#tadoOverlayForm').hide();
+                        $('#tadoReportDate').hide();
                         break;
                     case "setZoneOverlay":
                         $('#tadoHomeId').show();
                         $('#tadoZoneId').show();
                         $('#tadoDeviceId').hide();
                         $('#tadoOverlayForm').show();
+                        $('#tadoReportDate').hide();
                         break;
                     case "identifyDevice":
                         $('#tadoHomeId').hide();
                         $('#tadoZoneId').hide();
                         $('#tadoDeviceId').show();
                         $('#tadoOverlayForm').hide();
+                        $('#tadoReportDate').hide();
+                        break;
+                    case "getZoneDayReport":
+                        $('#tadoHomeId').show();
+                        $('#tadoZoneId').show();
+                        $('#tadoDeviceId').hide();
+                        $('#tadoOverlayForm').hide();
+                        $('#tadoReportDate').show();
                         break;
                 }
             });

--- a/tado.js
+++ b/tado.js
@@ -35,6 +35,7 @@ module.exports = function(RED) {
         this.terminationType = n.terminationType;
         this.terminationTimeout = n.terminationTimeout;
         this.name = n.name;
+	this.reportDate = n.reportDate;
 
         this.configName = n.configName;
         this.tadoConfig = RED.nodes.getNode(this.configName);
@@ -56,6 +57,7 @@ module.exports = function(RED) {
                         var temperature = msg.hasOwnProperty("temperature") ? msg.temperature : node.temperature;
                         var terminationType = msg.hasOwnProperty("terminationType") ? msg.terminationType : node.terminationType;
                         var terminationTimeout = msg.hasOwnProperty("terminationTimout") ? msg.terminationTimout : node.terminationTimeout;
+                        var reportDate = msg.hasOwnProperty("reportDate") ? msg.reportDate : node.reportDate;
 
                         var new_msg = {
                             topic: apiCall,
@@ -250,6 +252,19 @@ module.exports = function(RED) {
                                 });
 
                                 break;
+                            case "getZoneDayReport":
+                                tado.getZoneDayReport(homeId, zoneId, reportDate).then(function(resp) {
+                                    node.status({ fill: "green", shape: "dot", text: apiCall });
+                                    new_msg.payload = resp;
+                                    new_msg.zoneId = zoneId;
+                                    node.send(new_msg);
+                                }).catch(function(err) {
+                                    node.status({ fill: "red", shape: "ring", text: "errored" });
+                                    node.error(err);
+                                });
+
+                                break;
+
                         }
                     });
                 })


### PR DESCRIPTION
Hi there,

more info / depends on : PR https://github.com/mattdavis90/node-tado-client/pull/2. 

I passed through the zone id as `msg.zoneId`, which reduces the number of nearly identical nodes in a flow, when querying multiple zones..

One issue I could not fix : the Report Date is not saved in the node, I only got it working with injecting s.th. like `msg.reportDate: "2019-07-24"`

Cheers,
Markus

